### PR TITLE
Added --nest-top-dir flag to allow nestpy to be set to use user's NEST source code instead of that in src/nestpy/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,15 @@ set (CMAKE_CXX_STANDARD 11)
 cmake_minimum_required(VERSION 2.8.12)
 project(nestpy)
 # Set source directory
-set(SOURCE_DIR "src/nestpy")
+set(SOURCE_DIR "src/nestpy" CACHE PATH "NEST source directory")
 # Tell CMake that headers are also in SOURCE_DIR
-include_directories(${SOURCE_DIR})
+set(INCLUDE_DIR ${SOURCE_DIR} CACHE PATH "NEST include directory")
+include_directories(${INCLUDE_DIR} ${INCLUDE_DIR}/NEST ${INCLUDE_DIR}/Detectors)
 set(SOURCES "${SOURCE_DIR}/NEST.cpp" "${SOURCE_DIR}/NEST.cpp" "${SOURCE_DIR}/RandomGen.cpp"  "${SOURCE_DIR}/VDetector.cpp" "${SOURCE_DIR}/testNEST.cpp" "${SOURCE_DIR}/TestSpectra.cpp")
-include_directories("${SOURCE_DIR}/include") 
+
 
 # Generate Python module
 add_subdirectory(lib/pybind11)
-pybind11_add_module(nestpy ${SOURCES} "${SOURCE_DIR}/bindings.cpp")
+pybind11_add_module(nestpy ${SOURCES} "src/nestpy/bindings.cpp")
+unset(SOURCE_DIR CACHE)
+unset(INCLUDE_DIR CACHE)


### PR DESCRIPTION
usage: python setpy.py install --nest-top-dir="/path/to/NEST/"
(pip install nestpy --install-option="/path/to/NEST/" might work?)

Nest top dir should include src/ and include/ directories, as with the NEST git repo