### PR TITLE
Add Python 3.8 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,9 @@ matrix:
   - os: osx	
     osx_image: xcode9.4
     env: PYTHON=3.7
+  - os: osx	
+    osx_image: xcode9.4
+    env: PYTHON=3.8
     
 before_install:
     - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then source travis/setup-osx.sh; fi

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -7,7 +7,8 @@ yum install -y atlas-devel wget
 # Have to manually build and install CMake since libc old but
 # at least 2.8.12 is required for pybind11.
 cd /root
-wget --no-check-certificate https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
+#wget --no-check-certificate https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz # SSL too new on this server for old wget
+wget http://astroparticle.rice.edu/v2.8.12.tar.gz
 tar xfz v2.8.12.tar.gz
 cd CMake-2.8.12
 ./bootstrap > quiet_bootstrap

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -7,7 +7,7 @@ yum install -y atlas-devel wget
 # Have to manually build and install CMake since libc old but
 # at least 2.8.12 is required for pybind11.
 cd /root
-wget -q https://www.nikhef.nl/~ctunnell/v2.8.12.tar.gz
+wget -q https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
 tar xfz v2.8.12.tar.gz
 cd CMake-2.8.12
 ./bootstrap > quiet_bootstrap

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -7,7 +7,7 @@ yum install -y atlas-devel wget
 # Have to manually build and install CMake since libc old but
 # at least 2.8.12 is required for pybind11.
 cd /root
-wget https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
+wget --no-check-certificate https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
 tar xfz v2.8.12.tar.gz
 cd CMake-2.8.12
 ./bootstrap > quiet_bootstrap

--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -7,7 +7,7 @@ yum install -y atlas-devel wget
 # Have to manually build and install CMake since libc old but
 # at least 2.8.12 is required for pybind11.
 cd /root
-wget -q https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
+wget https://github.com/Kitware/CMake/archive/v2.8.12.tar.gz
 tar xfz v2.8.12.tar.gz
 cd CMake-2.8.12
 ./bootstrap > quiet_bootstrap


### PR DESCRIPTION
Based on an issue that @chloe-sl and @sophiaandaloro found, nestpy fails on Python3.8, at least from PyPI.   [They will expand].

This PR starts by adding a Python3.8 test to nestpy on TravisCI.  We will then modify this branch to see if we can get this fixed.
