### PR TITLE
include bindings to GRs ER model

### DIFF
--- a/src/nestpy/NEST.cpp
+++ b/src/nestpy/NEST.cpp
@@ -724,8 +724,12 @@ YieldResult NESTcalc::GetYields(INTERACTION_TYPE species, double energy, double 
     case fullGamma_PE:
       return GetYieldGamma(energy,density,dfield); //PE of the full gamma spectrum
     break;
+    case betaGR:
+      return GetYieldBetaGR(energy,density,dfield, NuisParam);
+    break;
     default:  // beta, CH3T, 14C, the pp solar neutrino background, and Compton/PP spectra of fullGamma
       return GetYieldBeta(energy,density,dfield);
+
       //return GetYieldBetaGR(energy,density,dfield,NuisParam);
     break;
   }

--- a/src/nestpy/NEST.hh
+++ b/src/nestpy/NEST.hh
@@ -125,7 +125,8 @@ typedef enum {
   fullGamma = 14,
   fullGamma_PE = 15,
   fullGamma_Compton_PP = 16,
-  NoneType =17
+  NoneType =17, 
+  betaGR = 18
 
 } INTERACTION_TYPE;
 

--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -54,6 +54,7 @@ PYBIND11_MODULE(nestpy, m) {
     .value("C14", NEST::INTERACTION_TYPE::C14)
     .value("Kr83m", NEST::INTERACTION_TYPE::Kr83m)
     .value("NoneType", NEST::INTERACTION_TYPE::NoneType)
+    .value("betaGR", NEST::INTERACTION_TYPE::betaGR)
     .export_values();
 
   //	Binding for the VDetector class


### PR DESCRIPTION
Should allow for users in nestpy to specify which ER model to use, between the normal Beta or Greg's. 
Changes: 
- Included new binding
- Case in NEST for Greg's model (break from c++ but can PR there too) 