### PR TITLE
fix version number for setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ requirements = open('requirements.txt').read().splitlines()
 
 setup(
     name='nestpy',
-    version='1.4.11',
+    version='1.5.0',
     author='Sophia Farrell',
     author_email='sja5@rice.edu',
     description='Python bindings for the NEST noble element simulations',


### PR DESCRIPTION
Really minor PR, but because there's a tag I want review on how best to do this, as tags are tricky. 

The point of this is to ensure that PyPi and thus pip recognize this as v1.5.0, as setup.py has the wrong version in place. I haven't found how safe it is to re-tag, but I'd hate to re-tag for something this small. Is there a way we can merge this, delete the tag, and re-tag immediately? I didn't want to overstep @grischbieter, since your documentation on v1.5.0 was great. So maybe if this looks good, we can merge, then if you agree this is minor enough to warrant a re-tag, we can delete/retag to this latest commit. 