### PR TITLE
Updated the DD spectrum in TestSpectra to have controllable parameters

### DIFF
--- a/src/nestpy/TestSpectra.cpp
+++ b/src/nestpy/TestSpectra.cpp
@@ -168,19 +168,19 @@ double TestSpectra::Cf_spectrum(double xMin, double xMax) {
   return xyTry[0];
 }
 
-double TestSpectra::DD_spectrum(
-    double xMin, double xMax) {  // JV LUX, most closely like JENDL-4. See
-                                 // arXiv:1608.05381. Lower than G4/LUXSim
+double TestSpectra::DD_spectrum(double xMin, double xMax, double expFall, double peakFrac, double peakMu, double peakSig) {
+// JV LUX, most closely like JENDL-4. See arXiv:1608.05381. Lower than G4/LUXSim
   if (xMax > 80.) xMax = 80.;
   if (xMin < 0.000) xMin = 0.000;
-  double yMax = 1.1;
+  double yMin = 0.0;
+  double yMax = 1. + peakFrac;
   vector<double> xyTry = {
       xMin + (xMax - xMin) * RandomGen::rndm()->rand_uniform(),
-      yMax * RandomGen::rndm()->rand_uniform(), 1.};
+      yMin + (yMax - yMin) * RandomGen::rndm()->rand_uniform(), 1.};
   while (xyTry[2] > 0.) {
     double FuncValue =
-        exp(-xyTry[0] / 10.) + 0.1 * exp(-pow((xyTry[0] - 60.) / 25., 2.));
-    xyTry = RandomGen::rndm()->VonNeumann(xMin, xMax, 0., yMax, xyTry[0],
+        exp(-xyTry[0] / expFall) + peakFrac * exp(-pow((xyTry[0] - peakMu) / peakSig, 2.));
+    xyTry = RandomGen::rndm()->VonNeumann(xMin, xMax, yMin, yMax, xyTry[0],
                                           xyTry[1], FuncValue);
   }
   return xyTry[0];

--- a/src/nestpy/TestSpectra.hh
+++ b/src/nestpy/TestSpectra.hh
@@ -54,7 +54,7 @@ class TestSpectra {
   static double B8_spectrum(double emin, double emax);
   static double AmBe_spectrum(double emin, double emax);
   static double Cf_spectrum(double emin, double emax);
-  static double DD_spectrum(double emin, double emax);
+  static double DD_spectrum(double xMin, double xMax, double expFall, double peakFrac, double peakMu, double peakSig);
   static double ppSolar_spectrum(double emin, double emax);
   static double atmNu_spectrum(double emin, double emax);
   static double WIMP_dRate(double ER, double mWimp, double day);

--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -212,7 +212,11 @@ PYBIND11_MODULE(nestpy, m) {
         .def_static("DD_spectrum",
               &TestSpectra::DD_spectrum,
               py::arg("xMin") = 0.,
-              py::arg("xMax") = 80.
+              py::arg("xMax") = 80.,
+	      py::arg("expFall") =  10.,
+	      py::arg("peakFrac") = 0.1,
+	      py::arg("peakMu") = 60.,
+	      py::arg("peakSig") = 25.
             )
         .def_static("ppSolar_spectrum", 
               &TestSpectra::ppSolar_spectrum,

--- a/src/nestpy/execNEST.cpp
+++ b/src/nestpy/execNEST.cpp
@@ -630,7 +630,7 @@ int execNEST(VDetector* detector, uint64_t numEvts, const string& type,
             keV = TestSpectra::Cf_spectrum(eMin, eMax);
             break;
           case DD:
-            keV = TestSpectra::DD_spectrum(eMin, eMax);
+            keV = TestSpectra::DD_spectrum(eMin, eMax, 10., 0.1, 60., 25.);
             break;
           case WIMP:
             keV = TestSpectra::WIMP_spectrum(spec.wimp_spectrum_prep, eMin,


### PR DESCRIPTION
I've synced TestSpectra.cpp, TestSpectra.hh, and execNEST.cpp to match the new DD spectrum in TestSpectra from the recent NEST commit: https://github.com/NESTCollaboration/nest/commit/a4952693ee559ab347f36f36fb1c0f3893f4d610

Core tests passed and spectrum works correctly, and all builds passed. So this should be good to merge. 