### PR TITLE
Integrated testing for multiple python versions

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -1,0 +1,36 @@
+# Test package every time
+name: Pytest
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  update:
+    name: "(${{ matrix.os }}, ${{ matrix.python-version }}, ${{ matrix.test }})"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: False
+      matrix:
+        os: [ "ubuntu-latest" ]
+        python-version: [ 2.7, 3.6, 3.7, 3.8, "3.9", "3.10" ]
+    steps:
+      - name: Setup python
+        uses: actions/setup-python@v2.3.1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Checkout repo
+        uses: actions/checkout@v2.4.0
+      - name: pre install numpy
+        if: matrix.python-version == 2.7 || matrix.python-version == 3.6
+        run: pip install numpy==1.13
+      - name: test install
+        run: |
+          pip install wheel
+          python setup.py test
+          python setup.py bdist_wheel

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        os: [ "ubuntu-latest" ]
-        python-version: [ 2.7, 3.6, 3.7, 3.8, "3.9", "3.10" ]
+        os: [ "ubuntu-latest" , "macos-latest"]
+        python-version: [ 2.7, 3.6, 3.7, 3.8, 3.9, "3.10" ]
     steps:
       - name: Setup python
         uses: actions/setup-python@v2.3.1
@@ -26,6 +26,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repo
         uses: actions/checkout@v2.4.0
+      - name: macos pre-install
+        if: matrix.os == 'macos-latest'
+        run: source travis/setup-osx.sh
       - name: pre install numpy
         if: matrix.python-version == 2.7 || matrix.python-version == 3.6
         run: pip install numpy==1.13


### PR DESCRIPTION
# Does nestpy work with python3.10?
I was wondering if python3.10 was working with nestpy. To test, I wrote a short github action, that allows for easy extension to other python versions. I also added a few that are specified in the setup.py (only py3.4 wasn't working for some reason). You can see the tests on https://github.com/JoranAngevaare/nestpy/pull/1, I think the actions aren't run here because this PR is from my own fork.

It appears that python3.10 is working on the master branch based on the testing 🎉! I will now try to figure out why it's failing on straxen:
https://github.com/XENONnT/straxen/pull/878

If you like github actions and you could adds this PR to your testing suite, it's free. If you don't because travis is working fine, please ignore my pull request.

# Edit
## Why does nestpy not work on py3.10?
Not sure, but it seems installing nestpy from source, rather than ` pip install nestpy==1.5.0`, [fixes the issue](https://github.com/XENONnT/straxen/pull/911).

## Failing test on this PR
Seems unrelated to this PR since other PRs and current master branch are also failing.
