### PR TITLE
only upload to pypi on release

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -17,9 +17,6 @@ on:
   workflow_dispatch:
   release:
     types: [ published ]
-  push:
-    tags:
-      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
this is the smarter way to go so our release notes are the thing that triggers the upload in the future.