### PR TITLE
Python binding to set random seed

### DIFF
--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -33,13 +33,12 @@ PYBIND11_MODULE(nestpy, m)
 	//-----------------------------------------------------------------------
 	// LXe NEST bindings
 	
-    // Init random seed with time
-    RandomGen::rndm()->SetSeed( time(nullptr) );
+	// Init random seed
+	RandomGen::rndm()->SetSeed( time(nullptr) );
 	// Binding for RandomGen class
 	py::class_<RandomGen>(m, "RandomGen")
 		.def("rndm", &RandomGen::rndm)
 		.def("set_seed", &RandomGen::SetSeed);
-                  
 
 	// Binding for YieldResult struct
 	py::class_<NEST::YieldResult>(m, "YieldResult", py::dynamic_attr())

--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -33,8 +33,14 @@ PYBIND11_MODULE(nestpy, m)
 	//-----------------------------------------------------------------------
 	// LXe NEST bindings
 	
-	RandomGen::rndm()->SetSeed( time(nullptr) );
-	
+    // Init random seed with time
+    RandomGen::rndm()->SetSeed( time(nullptr) );
+	// Binding for RandomGen class
+	py::class_<RandomGen>(m, "RandomGen")
+		.def("rndm", &RandomGen::rndm)
+		.def("set_seed", &RandomGen::SetSeed);
+                  
+
 	// Binding for YieldResult struct
 	py::class_<NEST::YieldResult>(m, "YieldResult", py::dynamic_attr())
 		.def(py::init<>())


### PR DESCRIPTION
I added a python binding to set the random seed from nestpy. The initial seed is still generated as before, this way existing code should not be affected.

Usage (sets the seed to 0):
```
import nestpy
rng = nestpy.RandomGen.rndm()  
rng.set_seed(0)
```