### PR TITLE
Remove warning on import + restart github tests

### DIFF
--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -38,3 +38,5 @@ jobs:
         run: |
           pip install wheel
           pip install .
+          python tests/core_nest_tests.py
+          python tests/example_tests.py

--- a/src/nestpy/helpers.py
+++ b/src/nestpy/helpers.py
@@ -40,6 +40,11 @@ NEST_INTERACTION_NUMBER = dict(
         nonetype=12,
     )
 
+
+# Add local variable to cache the NESTcalc(DETECTOR) object
+_NestCalcInit = dict()
+
+
 def ListInteractionTypes():
     return NEST_INTERACTION_NUMBER.keys()
 
@@ -63,7 +68,7 @@ def GetInteractionObject(name):
     return interaction_object
 
 @np.vectorize
-def GetYieldsVectorized(interaction, yield_type, nc=NESTcalc(DetectorExample_XENON10()), **kwargs):
+def GetYieldsVectorized(interaction, yield_type, nc=None, **kwargs):
     '''
     This function calculates nc.GetYields for the various interactions and arguments we pass into it.
 
@@ -76,6 +81,7 @@ def GetYieldsVectorized(interaction, yield_type, nc=NESTcalc(DetectorExample_XEN
 
     Parameters:
         nc (NESTcalc object): must specify nc=nestpy.NESTcalc(detector) to use non-default
+        if no argument is provided - a default is loaded and written to cache.
         interaction (str): interaction type, here using 'nr' (nuclear recoil),
         gammaray', 'beta', '206Pb', and 'alpha'.
         yield_type (str): Either 'PhotonYield' or 'ElectronYield' to return proper yield values.
@@ -89,6 +95,11 @@ def GetYieldsVectorized(interaction, yield_type, nc=NESTcalc(DetectorExample_XEN
         getattr(yield_object, yield_type) (array): array of yield values for a given yield_object (nr, etc)
         and a given yield_type (photon, electron yield as defined in parameters.)
     '''
+    if nc is None:
+        # Cache the default in _NestCalcInit
+        if 'default' not in _NestCalcInit:
+            _NestCalcInit['default'] = NESTcalc(DetectorExample_XENON10())
+        nc = _NestCalcInit['default']
     if type(interaction) == str:
         interaction_object = GetInteractionObject(interaction)
     else:


### PR DESCRIPTION
## Remove warning on import + restart github tests
As the title states, we add two small fixes/patches:
- https://github.com/JoranAngevaare/nestpy/pull/8
- https://github.com/JoranAngevaare/nestpy/pull/9

### Remove warning on import
Remove print on import. The print comes all the way from [this class ](https://github.com/NESTCollaboration/nest/blob/489cb24ca6a55471651c7ef724c50a7b4801df24/include/Detectors/DetectorExample_XENON10.hh#L23) - which I think is great to have when you are actually using this function - but otherwise doesn't make sense.

Do this by caching the NestCalc object only when the function is called (with the default arguments).

#### Before
```python
Run python -c "import nestpy; print(nestpy); print('bye bye')"
*** Detector definition message ***
You are currently using the default XENON10 template detector.

<module 'nestpy' from '/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/nestpy/__init__.py'>
bye bye
```

#### After
```python
Run python -c "import nestpy; print(nestpy); print('bye bye')"
<module 'nestpy' from '/opt/hostedtoolcache/Python/3.8.14/x64/lib/python3.8/site-packages/nestpy/__init__.py'>
bye bye
```

### Reactivate testing
Seems like testing was disabled in https://github.com/NESTCollaboration/nestpy/pull/93

Looking at some of the changes made there it looks like a different route was chosen than the testing suite provided by the `setup.py`, fine by me - probably would be good to disable that route altogether to avoid confusion.

Just to test that the desired behavior is re-established, I committed [7961b7e](https://github.com/JoranAngevaare/nestpy/pull/8/commits/7961b7eb32d7254d4fdc4ed2b88d477fac6c8de7).