### PR TITLE
Add lock of random seed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/nest"]
 	path = lib/nest
-	url = https://github.com/dachengx/nest # change this to any custom fork of NEST if you want to use your own code!
+	url = https://github.com/NESTCollaboration/nest # change this to any custom fork of NEST if you want to use your own code!
 [submodule "lib/gcem"]
 	path = lib/gcem
 	url = https://github.com/kthohr/gcem.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/nest"]
 	path = lib/nest
-	url = https://github.com/NESTCollaboration/nest # change this to any custom fork of NEST if you want to use your own code!
+	url = https://github.com/dachengx/nest # change this to any custom fork of NEST if you want to use your own code!
 [submodule "lib/gcem"]
 	path = lib/gcem
 	url = https://github.com/kthohr/gcem.git

--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -38,7 +38,9 @@ PYBIND11_MODULE(nestpy, m)
 	// Binding for RandomGen class
 	py::class_<RandomGen>(m, "RandomGen")
 		.def("rndm", &RandomGen::rndm)
-		.def("set_seed", &RandomGen::SetSeed);
+		.def("set_seed", &RandomGen::SetSeed)
+		.def("lock_seed", &RandomGen::LockSeed)
+		.def("unlock_seed", &RandomGen::UnlockSeed);
 
 	// Binding for YieldResult struct
 	py::class_<NEST::YieldResult>(m, "YieldResult", py::dynamic_attr())


### PR DESCRIPTION
Depends on https://github.com/NESTCollaboration/nest/pull/180

Add a lock of seed.

```
nest_rng = nestpy.RandomGen.rndm()
nest_rng.set_seed(0)
nest_rng.lock_seed()
nest_rng.set_seed(0)
```
will give you an error like
```
RuntimeError: You can not change the seed because it is locked.
```

if run
```
nest_rng.unlock_seed()
```
then `nest_rng.set_seed(0)` will not give you error.
