### PR TITLE
Updated workflows for github tests and PyPi

### DIFF
--- a/.github/workflows/pypi_install.yml
+++ b/.github/workflows/pypi_install.yml
@@ -31,6 +31,10 @@ jobs:
             os: "ubuntu-latest"
           - python-version: 3.7
             os: "ubuntu-latest"
+          - python-version: 3.6
+            os: "macos-latest"
+          - python-version: 3.7
+            os: "macos-latest"
           - python-version: 3.9
             os: "ubuntu-latest"
           - python-version: "3.10"

--- a/.github/workflows/test_package.yml
+++ b/.github/workflows/test_package.yml
@@ -19,6 +19,13 @@ jobs:
       matrix:
         os: [ "ubuntu-latest" , "macos-latest" ]
         python-version: [ 3.6, 3.7, 3.8, 3.9, "3.10" ]
+        exclude:
+          - python-version: 3.6
+            os: "ubuntu-latest"
+          - python-version: 3.6
+            os: "macos-latest"
+          - python-version: 3.7
+            os: "macos-latest"
     steps:
       - name: Setup python
         uses: actions/setup-python@v2.3.1

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,6 +2,7 @@
 
 ## Python bindings
 
+* Greg Rischbieter <rischbie@umich.edu> @grischbieter
 * Nicholas Carrara <ncarrara.physics@gmail.com> @infophysics
 * Sophia Andaloro <sja5@rice.edu> @sophiaandaloro
 * Christopher Tunnell <tunnell@rice.edu> @tunnell


### PR DESCRIPTION
Excluded the macos-latest Python 3.6 and 3.7 tests, as github doesn't have those available for testing