### PR TITLE
Update cmake policy to recent cmake release & update pybind11 version…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set (CMAKE_CXX_STANDARD 17)
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 2.8.12...3.30)
 project(nestpy)
 
 # Set source directory


### PR DESCRIPTION
… to support new cmake release

This updates the cmake policy version and Pybind11 versions so that nestpy can be built using modern versions of cmake

Close #113 