### PR TITLE
Simplify the interactions object and update the readme

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,19 @@ History
 
 Patch releases mean (the Z number in X.Y.Z version) that the underlying physics has not changed.  Changes to the NEST version will always trigger a minor or major release.  If this library changes such that end users have to change their code, this may also trigger a minor or major release.
 
+2.1.1 (2026-04-01)
+------------------
+
+Major changes:
+  * Added all of NEST's interactions types to the python bindings
+  * Consolidated interaction type access to only support renamed `nestpy.interactions.<>` (for instance `nestpy.interactions.NR`). 
+
+Breaking changes:
+  * Removed non `nestpy.interactions.<>` methods for accessing NEST interactions.  This means we support only one obvious way of selecting interactions removing confusion and duplicated code
+
+Minor changes:
+  * Made `helpers.py` functions use `VDetector` opposed to XENON detector for detector independent calculations (namely yield calculations)
+
 2.1.0 (2026-03-09)
 ------------------
 Major Changes:

--- a/README.md
+++ b/README.md
@@ -63,11 +63,13 @@ In order to create a more efficient workflow, we suggest the user takes the foll
 
 Python bindings to the NEST library:
 
+### Simple example covering the basic logic behind NEST
+
 ```
 import nestpy
 
 # This is same as C++ NEST with naming
-nc = nestpy.NESTcalc(nestpy.VDetector())
+nc = nestpy.NESTcalc(nestpy.detectors.VDetector())
 
 interaction = nestpy.INTERACTION_TYPE(0)  # NR
 
@@ -82,6 +84,45 @@ print('The photon yield is:', y.PhotonYield)
 print('With statistical fluctuations',
       nc.GetQuanta(y).photons)
 ```
+
+### Examples using a vectorised approach
+
+Get the yields as a function of energy
+
+```
+# Want to use custom yields parameters (e.g. from LZ WS2024)
+lz_2024 = nestpy.detectors.LZ_WS2024()
+# Get yields as a dataframe 
+energy = np.linspace(1, 10, 10000)
+nr_yeild = nestpy.helpers.get_yields_df(ne.interactions.NR, energy)
+er_devel_yield = ne.helpers.get_yields_df(ne.interactions.beta, energy, nr_parameters = lz_2024.nr_parameters, er_parameters = lz_2024.er_parameters)
+```
+
+Run a vectorised simulation of S1 and S2 parameters 
+
+```
+n = int(1e5)
+
+t = nestpy.helpers.run_nest_df(
+    # "beta",
+    nestpy.interactions.beta,
+    lz_2024,
+    nestpy.spectra.CH3T(number=n), # Vectorised sampler from energy spectra
+    # By default uses random positions in the detector
+)
+
+d = nestpy.helpers.run_nest_df(
+    nestpy.interactions.NR,
+    lz_2024,
+    ne.spectra.DD(number=n),
+    # nr_yield_params = det.nr_yield_params <- can set custom yield parameters
+    # er_yield_params = det.er_yield_params <- can set custom yield parameters
+    # width_params = det.width_yield_params <- can set this too
+    # s1_mode" = NEST::S1CalculationMode::Hybrid <- Can simulate more detailed calculation or waveforms
+    # s2_mode" = NEST::S2CalculationMode::Full <- Can simulate Waveforms with E-trains
+)
+```
+
 
 For more examples on possible calls, please see the tests and tutorials folders.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import nestpy
 # This is same as C++ NEST with naming
 nc = nestpy.NESTcalc(nestpy.detectors.VDetector())
 
-interaction = nestpy.INTERACTION_TYPE(0)  # NR
+interaction = nestpy.interactions.NR  # NR
 
 E = 10  # keV
 print('For an %s keV %s' % (E, interaction))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,11 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "nestpy"
-version = "2.1.0"
+version = "2.1.1"
 description = "Python bindings for the NEST noble element simulation"
 authors = [
     {name = "Sam Eriksen", email = "sam.eriksen@bristol.ac.uk"},
-    {name = "Albert Baker", email = "k2371191@kcl.ac.uk"},
+    {name = "Albert (albert-physics)"},
     {name = "Greg Rischbieter", email = "rischbie@umich.edu"},
     {name = "Nicholas Carrara", email = "ncarrara.physics@gmail.com"},
     {name = "Sophia Andaloro", email = "sja5@rice.edu"},

--- a/src/nestpy/__init__.py
+++ b/src/nestpy/__init__.py
@@ -1,8 +1,4 @@
 from ._nestpy import * 
 from ._nestpy import __nest_version__
 
-from .helpers import Yield, PhotonYield, ElectronYield, GetYieldsVectorized, GetInteractionObject, ListInteractionTypes
-
-# Populate namespace with interaction types to allow e.g. nestpy.NR
-for interaction_type in ListInteractionTypes(): # interaction_type is string
-    vars()[interaction_type] = GetInteractionObject(interaction_type)
+from .helpers import Yield, PhotonYield, ElectronYield, GetYieldsVectorized

--- a/src/nestpy/bindings.cpp
+++ b/src/nestpy/bindings.cpp
@@ -77,19 +77,26 @@ PYBIND11_MODULE(_nestpy, m)
 
 
 	//	Binding for the enumeration INTERACTION_TYPE
-	py::enum_<NEST::INTERACTION_TYPE>(m, "INTERACTION_TYPE", py::arithmetic())
+	py::enum_<NEST::INTERACTION_TYPE>(m, "interactions", py::arithmetic())
+		// nuclear recoil
 		.value("NR", NEST::INTERACTION_TYPE::NR)
 		.value("WIMP", NEST::INTERACTION_TYPE::WIMP)
 		.value("B8", NEST::INTERACTION_TYPE::B8)
 		.value("DD", NEST::INTERACTION_TYPE::DD)
 		.value("AmBe", NEST::INTERACTION_TYPE::AmBe)
 		.value("Cf", NEST::INTERACTION_TYPE::Cf)
-		.value("ion", NEST::INTERACTION_TYPE::ion)
-		.value("gammaRay", NEST::INTERACTION_TYPE::gammaRay)
-		.value("beta", NEST::INTERACTION_TYPE::beta)
+		.value("ion", NEST::INTERACTION_TYPE::ion)  // includes alphas, Pb-206
+		// electron recoil
+		.value("gammaRay", NEST::INTERACTION_TYPE::gammaRay)  // only photoelectric
+		.value("beta", NEST::INTERACTION_TYPE::beta)      // includes comptons
 		.value("CH3T", NEST::INTERACTION_TYPE::CH3T)
 		.value("C14", NEST::INTERACTION_TYPE::C14)
 		.value("Kr83m", NEST::INTERACTION_TYPE::Kr83m)
+		.value("ppSolar", NEST::INTERACTION_TYPE::ppSolar)
+		.value("atmNu", NEST::INTERACTION_TYPE::atmNu)
+		.value("fullGamma", NEST::INTERACTION_TYPE::fullGamma)
+		.value("fullGamma_PE", NEST::INTERACTION_TYPE::fullGamma_PE)
+		.value("fullGamma_Compton_PP", NEST::INTERACTION_TYPE::fullGamma_Compton_PP)
 		.value("NoneType", NEST::INTERACTION_TYPE::NoneType)
 		.export_values();
 

--- a/src/nestpy/helpers.py
+++ b/src/nestpy/helpers.py
@@ -29,14 +29,12 @@ def get_all_yields(interaction, energy, nest_calc=NESTcalc(VDetector()), **kwarg
 
     Args:
         energy (array[float]): An array of energies in keV
-        interaction (INTERACTION_TYPE): The type of interaction be studied
+        interaction (nestpy.interactions): The type of interaction be studied
         nest_calc (NESTCalc): A NEST calculator defined for a given detector
 
     Returns:
         list[YieldResult]: A list of NEST yield objects
     """
-
-    interaction = GetInteractionObject(interaction) if isinstance(interaction, str) else interaction
 
     return nest_calc.GetYields(energy=energy, interaction=interaction, **kwargs)
 

--- a/src/nestpy/helpers.py
+++ b/src/nestpy/helpers.py
@@ -43,7 +43,7 @@ def get_yields_df(interaction, energy, nest_calc=NESTcalc(VDetector()), **kwargs
 
     Args:
         energy (array[float]): An array of energies in keV
-        interaction (INTERACTION_TYPE): The type of interaction be studied
+        interaction (nestpy.interactions): The type of interaction be studied
         nest_calc (NESTCalc): A NEST calculator defined for a given detector
 
     Returns:
@@ -62,8 +62,8 @@ def GetYieldsVectorized(interaction, yield_type, nc=None, detector=None, **kwarg
     This function calculates nc.GetYields for the various interactions and arguments we pass into it.
 
     Requires:
-        - GetInteractionObject from interactionkeys
-            - strings passed through get us the numeric equivalent for each interaction
+        - ne.interactions
+            - An object defining the interaction type
         - energy array
         - nc.GetYields (pass through interaction, energies, field value)
             - Returns dictionary with yield types and yield values at each interaction energy value.
@@ -173,8 +173,6 @@ def run_nest(
 ):
 
     energy = np.asarray(energy)
-
-    interaction = GetInteractionObject(interaction) if isinstance(interaction, str) else interaction
 
     # If no position given then randomly sample
     if positions is None:

--- a/src/nestpy/helpers.py
+++ b/src/nestpy/helpers.py
@@ -14,65 +14,17 @@ Main ingredients for the above steps:
 
 import numpy as np
 
-from ._nestpy import NESTcalc, INTERACTION_TYPE, array # This is C++ library
-from ._nestpy.detectors import DetectorExample_XENON10
+from ._nestpy import NESTcalc, array # This is C++ library
+from ._nestpy.detectors import VDetector
 import awkward as ak
 import pandas as pd
-
-
-# Detector identification for default
-# Performing NEST calculations according to the given detector example.
-# Yields are ambivalent to detector.
-# DETECTOR = DetectorExample_XENON10()
-# NC = NESTcalc(DETECTOR)
-
-NEST_INTERACTION_NUMBER = dict(
-    nr=0,
-    wimp=1,
-    b8=2,
-    dd=3,
-    ambe=4,
-    cf=5,
-    ion=6,
-    gammaray=7,
-    beta=8,
-    ch3t=9,
-    c14=10,
-    kr83m=11,
-    nonetype=12,
-)
 
 
 # Add local variable to cache the NESTcalc(DETECTOR) object
 _NestCalcInit = dict()
 
-
-def ListInteractionTypes():
-    return NEST_INTERACTION_NUMBER.keys()
-
-
-def GetInteractionObject(name):
-    """
-    This function returns the NEST interaction object for a given string.
-    Parameters:
-        name (str): interaction type (e.g. 'NR' or 'nr'.)
-                    To see all options available, run nestpy.ListInteractionTypes().
-
-    Returns:
-        nestpy.INTERACTION_TYPE(Number), where Number corresponds to the string you provided.
-    """
-
-    name = name.lower()
-
-    if name == "er":
-        raise ValueError("For 'er', specify either 'gammaray' or 'beta'")
-
-    interaction_object = INTERACTION_TYPE(NEST_INTERACTION_NUMBER[name])
-    return interaction_object
-
-
 @np.vectorize(excluded={"nr_parameters", "er_parameters"})
-def get_all_yields(interaction, energy, nest_calc=NESTcalc(DetectorExample_XENON10()), **kwargs):
+def get_all_yields(interaction, energy, nest_calc=NESTcalc(VDetector()), **kwargs):
     """Get a list of NEST yield objects
 
     Args:
@@ -88,7 +40,7 @@ def get_all_yields(interaction, energy, nest_calc=NESTcalc(DetectorExample_XENON
 
     return nest_calc.GetYields(energy=energy, interaction=interaction, **kwargs)
 
-def get_yields_df(interaction, energy, nest_calc=NESTcalc(DetectorExample_XENON10()), **kwargs):
+def get_yields_df(interaction, energy, nest_calc=NESTcalc(VDetector()), **kwargs):
     """Get a pandas dataframe of the yield parameters for an interaction
 
     Args:
@@ -137,14 +89,10 @@ def GetYieldsVectorized(interaction, yield_type, nc=None, detector=None, **kwarg
     if nc is None:
         # Cache the default in _NestCalcInit
         if "default" not in _NestCalcInit:
-            _NestCalcInit["default"] = NESTcalc(DetectorExample_XENON10())
+            _NestCalcInit["default"] = NESTcalc(VDetector())
         nc = _NestCalcInit["default"]
-    if type(interaction) == str:
-        interaction_object = GetInteractionObject(interaction)
-    else:
-        interaction_object = interaction
 
-    yield_object = nc.GetYields(interaction=interaction_object, **kwargs)
+    yield_object = nc.GetYields(interaction=interaction, **kwargs)
     # returns the yields for the type of yield we are considering
     return getattr(yield_object, yield_type)
 

--- a/tests/core_nest_tests.py
+++ b/tests/core_nest_tests.py
@@ -33,10 +33,10 @@ class ConstructorTest(unittest.TestCase):
         assert isinstance(nestcalc, nestpy.NESTcalc)
 
     def test_intteraction_type_constructor(self):
-        it = nestpy.INTERACTION_TYPE(0)
+        it = nestpy.interactions.NR
         assert it is not None
         assert str(it) != ""
-        assert isinstance(it, nestpy.INTERACTION_TYPE)
+        assert isinstance(it, nestpy.interactions)
 
 
 class VDetectorTest(unittest.TestCase):
@@ -45,7 +45,7 @@ class VDetectorTest(unittest.TestCase):
    def setUpClass(cls):
        cls.detector = nestpy.detectors.VDetector()
        cls.detector.Initialization()
-       cls.it = nestpy.INTERACTION_TYPE(0)
+       cls.it = nestpy.interactions.NR
        cls.nestcalc = nestpy.NESTcalc(cls.detector)
        cls.nuisance = cls.nestcalc.default_nr_parameters
        cls.free = cls.nestcalc.default_nr_er_width_parameters
@@ -69,16 +69,12 @@ class NESTcalcTest(unittest.TestCase):
     def setUpClass(cls):
         cls.detector = nestpy.detectors.VDetector()
         cls.detector.Initialization()
-        cls.it = nestpy.INTERACTION_TYPE(0)
+        cls.it = nestpy.interactions.NR
         cls.nestcalc = nestpy.NESTcalc(cls.detector)
 
         cls.nuisance = cls.nestcalc.default_nr_parameters
         cls.free = cls.nestcalc.default_nr_er_width_parameters
         cls.er_params = cls.nestcalc.default_er_parameters
-
-    def test_interaction_type_constructor(self):
-        for i in range(5):
-            it = nestpy.INTERACTION_TYPE(i)
 
     def test_nestcalc_full_calculation(self):
         result = self.nestcalc.FullCalculation(self.it, 1., 2., 3., 4, 5,
@@ -96,11 +92,11 @@ class NESTcalcTest(unittest.TestCase):
             self.it, 10., 10., 10., 10., 10., self.nuisance)
 
     def test_nestcalc_get_yields_defaults(self):
-        yields = self.nestcalc.GetYields(nestpy.INTERACTION_TYPE(0),
+        yields = self.nestcalc.GetYields(nestpy.interactions.NR,
                                          10)
 
     def test_nestcalc_get_yields_named(self):
-        yields = self.nestcalc.GetYields(nestpy.INTERACTION_TYPE(0),
+        yields = self.nestcalc.GetYields(nestpy.interactions.NR,
                                          energy=10)
 
     # def test_nestcalc_get_spike(self):
@@ -138,7 +134,7 @@ class NESTcalcTest(unittest.TestCase):
 
     def test_equality(self):
         # Will call a test for the nearlyEqual function to ensure it still works.
-        self.nestcalc.GetYields(nestpy.INTERACTION_TYPE(0), 100., 2.9, 100., 0., 54, nestpy.default_nr_parameters, nestpy.default_er_parameters)
+        self.nestcalc.GetYields(nestpy.interactions.NR, 100., 2.9, 100., 0., 54, nestpy.default_nr_parameters, nestpy.default_er_parameters)
 
 
 class TestSpectraWIMPTest(unittest.TestCase):
@@ -157,7 +153,7 @@ class NESTcalcFullCalculationTest(unittest.TestCase):
     def setUpClass(cls):
         cls.detector = nestpy.detectors.VDetector()
         cls.detector.Initialization()
-        cls.it = nestpy.INTERACTION_TYPE(0)
+        cls.it = nestpy.interactions.NR
 
         cls.nestcalc = nestpy.NESTcalc(cls.detector)
         cls.nuisance = cls.nestcalc.default_nr_parameters

--- a/tests/example_tests.py
+++ b/tests/example_tests.py
@@ -9,7 +9,7 @@ class nestpyExamplesTest(unittest.TestCase):
         # This is same as C++ NEST with naming
         nc = nestpy.NESTcalc(nestpy.detectors.VDetector())
         
-        interaction = nestpy.INTERACTION_TYPE(0)  # NR
+        interaction = nestpy.interactions.NR  # NR
         
         E = 10  # keV
         print('For an %s keV %s' % (E, interaction))


### PR DESCRIPTION
Close #125 #124 

This MR makes the code use VDetector opposed to the XENON example when computing quantities that do not depend on the detector (like the yields)

This MR also removes the majority of the myriad of interaction accessors so that there is one and only one ambiguous method to specify an interaction.  Whilst adding this the MR also adds the missing interactions from NEST